### PR TITLE
Fix broken post images via path normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import posts from '../../data/posts';
+import { resolveImagePath } from '../../utils/image';
 
 export default function ArticlePage() {
   const router = useRouter();
@@ -28,7 +29,7 @@ export default function ArticlePage() {
         <a style={{ color: 'var(--primary)', display: 'inline-block', marginBottom: '1rem' }}>← Back to Home</a>
       </Link>
       <img
-        src={`/images/${post.image}`}
+        src={resolveImagePath(post.image)}
         alt={post.title}
         style={{ width: '100%', height: '300px', objectFit: 'cover', borderRadius: '8px' }}
       />
@@ -65,7 +66,7 @@ export default function ArticlePage() {
                   }}
                 >
                   <img
-                    src={`/images/${rec.image}`}
+                    src={resolveImagePath(rec.image)}
                     alt={rec.title}
                     style={{ width: '100%', height: '150px', objectFit: 'cover' }}
                   />

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import posts from '../data/posts';
+import { resolveImagePath } from '../utils/image';
 
 // Define the order of categories shown on the home page. The "All"
 // category is implicit and handled in component state.
@@ -195,7 +196,7 @@ export default function Home() {
               style={{ backgroundColor: '#fff', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.05)', overflow: 'hidden' }}
             >
               <img
-                src={`/images/${post.image}`}
+                src={resolveImagePath(post.image)}
                 alt={post.title}
                 style={{ width: '100%', height: '180px', objectFit: 'cover' }}
               />

--- a/utils/image.js
+++ b/utils/image.js
@@ -1,0 +1,13 @@
+export function resolveImagePath(path) {
+  if (!path) return '';
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+  if (path.startsWith('/')) {
+    return path;
+  }
+  if (path.startsWith('images/')) {
+    return '/' + path;
+  }
+  return `/images/${path}`;
+}


### PR DESCRIPTION
## Summary
- handle absolute URLs and existing paths for post images
- use shared `resolveImagePath` helper
- ignore build artifacts and dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1afc087dc832d8adffbebc540298d