### PR TITLE
Prune unused categories and streamline filters

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -7,11 +7,7 @@ import posts from '../data/posts';
 const CATEGORY_ORDER = [
   'Popular',
   'AI',
-  'Tech',
-  'Finance',
-  'Politics',
-  'Exam',
-  'Lifestyle'
+  'Tech'
 ];
 
 export default function Home() {
@@ -38,14 +34,10 @@ export default function Home() {
     fetchTrending();
   }, []);
 
-  // Filter posts based on the selected category. For the Exam
-  // category, we treat all exam subcategories as Exam for the
-  // top‑level filter. When "All" is selected, return all posts.
+  // Filter posts based on the selected category. When "All" is
+  // selected, return all posts.
   const filteredPosts = posts.filter((post) => {
     if (selectedCategory === 'All') return true;
-    if (selectedCategory === 'Exam') {
-      return post.category === 'Exam';
-    }
     return post.category === selectedCategory;
   });
 


### PR DESCRIPTION
## Summary
- Remove obsolete categories from home page menu
- Simplify post filtering logic to match remaining categories

## Testing
- `node -e "import('./data/posts.js').then(m=>{const posts=m.default; ['AI','Tech','Popular'].forEach(c=>{const filtered=posts.filter(p=>{if(c==='All') return true; return p.category===c;}); console.log(c, filtered.length);});});"`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1b921ac48832db7625e2b2bfa7fd6